### PR TITLE
Extension: httpRequestFactory incorrect type fixed

### DIFF
--- a/src/Kdyby/Console/DI/ConsoleExtension.php
+++ b/src/Kdyby/Console/DI/ConsoleExtension.php
@@ -112,7 +112,7 @@ class ConsoleExtension extends Nette\DI\CompilerExtension
 				throw new Nette\Utils\AssertionException("The url '{$config['url']}' is not valid, please use this format: 'http://domain.tld/path'.");
 			}
 			$builder->getDefinition('nette.httpRequestFactory')
-				->setClass('Kdyby\Console\HttpRequestFactory')
+				->setFactory('Kdyby\Console\HttpRequestFactory')
 				->addSetup('setFakeRequestUrl', array($config['url']));
 		}
 


### PR DESCRIPTION
Using Nette\DI 2.2.3.

Possible BC break by changes in Nette\DI between 2.2.2 and 2.2.3, but not sure.
Maybe related to this commit: https://github.com/nette/di/commit/4ee1cf5317a4a730c9bfa0cda673f550bdf2d3ad


With `setClass` only, incorrect type is checked in `instanceof`

**Before**: 

![before](https://cloud.githubusercontent.com/assets/924196/6257708/db66c204-b7c2-11e4-92d5-4c37d83ffecd.png)

**After**:

![after](https://cloud.githubusercontent.com/assets/924196/6257715/e3dbc416-b7c2-11e4-99ca-5db5964e15cb.png)



