### PR TITLE
StringOutput::getOutput() returns an empty string instead of null

### DIFF
--- a/src/Kdyby/Console/StringOutput.php
+++ b/src/Kdyby/Console/StringOutput.php
@@ -25,7 +25,7 @@ class StringOutput extends Output
 	/**
 	 * @var string
 	 */
-	private $output;
+	private $output = '';
 
 
 


### PR DESCRIPTION
So that it's consistent with the phpDoc annotation.