### PR TITLE
Bugfix: fixed the test for PR 45 (no issue nr)

### DIFF
--- a/tests/KdybyTests/Console/InputErrors.phpt
+++ b/tests/KdybyTests/Console/InputErrors.phpt
@@ -381,7 +381,7 @@ class SameArgsCommandOne extends Symfony\Component\Console\Command\Command
 class SameArgsCommandTwo extends Symfony\Component\Console\Command\Command
 {
 
-	public function __construct(ArgCommand $argCommand, TypoCommand $typoCommand)
+	public function __construct(ArgCommand $argCommand1, ArgCommand $argCommand2)
 	{
 		parent::__construct();
 	}

--- a/tests/KdybyTests/Console/config/input-errors.neon
+++ b/tests/KdybyTests/Console/config/input-errors.neon
@@ -11,4 +11,4 @@ console:
 
 services:
 	service1: KdybyTests\Console\ArgCommand
-	service2: KdybyTests\Console\TypoCommand
+	service2: KdybyTests\Console\ArgCommand


### PR DESCRIPTION
As I'm working on issue # 48, I noticed that original PR in tests had a wrong assumption. Original bugfix tried to fix two commands with same argument names - which is allright.

**BUT** nette-di-autowire-by-default policy means, that you'd in fact declare services into args only when they cannot be auto resolved. This updates the test accoardingly.

Note that autowire - resolve - problems will be part of separate PR, which will fix # 48 . Thus, this is a separate PR, which just updates the testcase for the PR 45
