### PR TITLE
[BC BREAK] Full blown DI for console commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,25 @@ The best way to install Kdyby/Console is using  [Composer](http://getcomposer.or
 $ composer require kdyby/console
 ```
 
+Then enable the extension in your `config.neon`:
+
+```yml
+extensions:
+	console: Kdyby\Console\DI\ConsoleExtension
+```
+
+And append your commands into `console` section:
+```yml
+console:
+	disable: false      # optional, can be used to disable console extension entirely
+	helpers:            # optional, helpers go here
+		- App\Console\FooHelper 
+	commands:           # define your commands in this section. Full Nette DI is supported.
+		- App\Console\SendNewslettersCommand 
+		- App\Console\AnotherCommand 
+		- App\Console\AnotherCommand2
+```
+
 
 Documentation
 ------------

--- a/src/Kdyby/Console/DI/ConsoleExtension.php
+++ b/src/Kdyby/Console/DI/ConsoleExtension.php
@@ -90,8 +90,6 @@ class ConsoleExtension extends Nette\DI\CompilerExtension
 				$def->class = $def->factory->entity;
 			}
 
-			$def->setAutowired(FALSE);
-			$def->setInject(FALSE);
 			$def->addTag(self::TAG_COMMAND);
 		}
 	}

--- a/src/Kdyby/Console/DI/ConsoleExtension.php
+++ b/src/Kdyby/Console/DI/ConsoleExtension.php
@@ -82,14 +82,7 @@ class ConsoleExtension extends Nette\DI\CompilerExtension
 		Nette\Utils\Validators::assert($config, 'array');
 		foreach ($config['commands'] as $i => $command) {
 			$def = $builder->addDefinition($this->prefix('command.' . $i));
-			list($def->factory) = Nette\DI\Compiler::filterArguments(array(
-				is_string($command) ? new Statement($command) : $command
-			));
-
-			if (class_exists($def->factory->entity)) {
-				$def->class = $def->factory->entity;
-			}
-
+			Nette\DI\Compiler::parseService($def, $command);
 			$def->addTag(self::TAG_COMMAND);
 		}
 	}

--- a/src/Kdyby/Console/DI/ConsoleExtension.php
+++ b/src/Kdyby/Console/DI/ConsoleExtension.php
@@ -85,6 +85,13 @@ class ConsoleExtension extends Nette\DI\CompilerExtension
 			Nette\DI\Compiler::parseService($def, $command);
 			$def->addTag(self::TAG_COMMAND);
 		}
+
+		isset($config['helpers']) ?: $config['helpers'] = [];
+		foreach ($config['helpers'] as $i => $helper) {
+			$def = $builder->addDefinition($this->prefix('helper.' . $i));
+			Nette\DI\Compiler::parseService($def, $helper);
+			$def->addTag(self::TAG_HELPER);
+		}
 	}
 
 

--- a/tests/KdybyTests/Console/DiWiring.phpt
+++ b/tests/KdybyTests/Console/DiWiring.phpt
@@ -1,0 +1,416 @@
+<?php
+
+/**
+ * Test: Full DI tests for commands
+ *
+ * @testCase Kdyby\Console\DiWiring
+ * @author Pavel Ptacek <ptacek.pavel@gmail.com>
+ * @package Kdyby\Console
+ */
+
+namespace KdybyTests\Console\DI;
+
+use Kdyby;
+use Nette;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Helper;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Tester;
+use Tester\Assert;
+use Tracy\Debugger;
+
+require_once __DIR__ . '/../bootstrap.php';
+require_once __DIR__ . '/CliAppTester.php';
+
+
+
+/**
+ * @author Pavel Ptacek <ptacek.pavel@gmail.com>
+ */
+class DiWiringTest extends Tester\TestCase
+{
+	/**
+	 * @return Nette\DI\Container
+	 */
+	private function createContainer()
+	{
+		Debugger::$logDirectory = TEMP_DIR . '/log';
+		Tester\Helpers::purge(Debugger::$logDirectory);
+
+		$config = new Nette\Configurator();
+		$config->setTempDirectory(TEMP_DIR);
+		$config->setDebugMode(TRUE);
+		$config->addConfig(__DIR__ . '/config/di-wiring.neon', $config::NONE);
+		$config->addConfig(__DIR__ . '/config/allow.neon', $config::NONE);
+
+		return $config->createContainer();
+	}
+
+	/**
+	 * Create containers from configuration
+	 */
+	public function testContainerCreation()
+	{
+		$app = $this->createContainer()->getService('console.application');
+		Assert::true(
+			$app instanceof Kdyby\Console\Application,
+			'Application was not created using container->getService(console.application)'
+		);
+
+		$app = $this->createContainer()->getByType('Kdyby\Console\Application');
+		Assert::true(
+			$app instanceof Kdyby\Console\Application,
+			'Application was not created using container->getByType(Kdyby\Console\Application)'
+		);
+	}
+
+	/**
+	 * Create commands and get their execution
+	 */
+	public function testCommands()
+	{
+		/** @var $app Kdyby\Console\Application */
+		$app = $this->createContainer()->getByType('Kdyby\Console\Application');
+
+		$tests = [
+			CommandInCommands::COMMAND_NAME => CommandInCommands::RETURN_CODE,
+			CommandAsService::COMMAND_NAME => CommandAsService::RETURN_CODE,
+			CommandInCommandsNeedsAll::COMMAND_NAME => CommandInCommandsNeedsAll::RETURN_CODE,
+			CommandAsServiceNeedsAll::COMMAND_NAME => CommandAsServiceNeedsAll::RETURN_CODE,
+			CommandInCommandsNeedsAllWithInject::COMMAND_NAME => CommandInCommandsNeedsAllWithInject::RETURN_CODE,
+			CommandAsServiceNeedsAllWithInject::COMMAND_NAME => CommandAsServiceNeedsAllWithInject::RETURN_CODE,
+		];
+
+		$null = new NullOutput();
+		foreach($tests as $command => $returnCode) {
+			Assert::same(
+				$returnCode,
+				$app->run(new ArgvInput(['www/index.php', $command]), $null),
+				'Exit code check: '.$command.' did not run properly'
+			);
+		}
+	}
+
+	/**
+	 * Validate that helpers are injected properly
+	 */
+	public function testHelpers()
+	{
+		/** @var $app Kdyby\Console\Application */
+		$app = $this->createContainer()->getByType('Kdyby\Console\Application');
+
+		/** @var $command CommandInCommands */
+		$command = $app->find(CommandInCommands::COMMAND_NAME);
+		$command->validateHelpers();
+	}
+
+	/**
+	 * Validate that all injections are properly inserted by DI
+	 */
+	public function testInjections()
+	{
+		/** @var $app Kdyby\Console\Application */
+		$app = $this->createContainer()->getByType('Kdyby\Console\Application');
+
+		/** @var $command CommandInCommandsNeedsAll */
+		$command = $app->get(CommandInCommandsNeedsAll::COMMAND_NAME);
+		$command->validateNotAnnotations();
+		$command->validateConstructor();
+		$command->validateNotInjector();
+
+		/** @var $command CommandAsServiceNeedsAll */
+		$command = $app->find(CommandAsServiceNeedsAll::COMMAND_NAME);
+		$command->validateNotAnnotations();
+		$command->validateConstructor();
+		$command->validateNotInjector();
+
+		/** @var $command CommandInCommandsNeedsAll */
+		$command = $app->get(CommandInCommandsNeedsAllWithInject::COMMAND_NAME);
+		$command->validateAnnotations();
+		$command->validateConstructor();
+		$command->validateInjector();
+
+		/** @var $command CommandAsServiceNeedsAll */
+		$command = $app->find(CommandAsServiceNeedsAllWithInject::COMMAND_NAME);
+		$command->validateAnnotations();
+		$command->validateConstructor();
+		$command->validateInjector();
+	}
+}
+
+/**
+ * Basic test for return code on all commands, test for helper blueprint
+ * @package KdybyTests\Console\DI
+ */
+abstract class DiTestCommand extends Command
+{
+	const COMMAND_NAME = 'n/a';
+	const RETURN_CODE = 10;
+
+	public function __construct()
+	{
+		parent::__construct(static::COMMAND_NAME);
+	}
+
+	public function execute(InputInterface $input, OutputInterface $output)
+	{
+		return static::RETURN_CODE;
+	}
+
+	public function validateHelpers()
+	{
+		Assert::type('KdybyTests\Console\DI\HelperInSection', $this->getHelper('HelperInSection'), 'helper in section');
+		Assert::type('KdybyTests\Console\DI\HelperAsService', $this->getHelper('HelperAsService'), 'helper as service');
+	}
+}
+
+/**
+ * Basic class for dependant commands - those, that use the trait - boilerplate
+ * @package KdybyTests\Console\DI
+ */
+abstract class DiTestDependantCommand extends DiTestCommand
+{
+	/**
+	 * Load dependency tester trait
+	 */
+	use DependencyTesterTrait {
+		DependencyTesterTrait::__construct as private __dttConstruct;
+	}
+
+	/**
+	 * @param CommandInCommands $commandInCommands
+	 * @param TestService $testService
+	 * @param CommandAsService $commandAsService
+	 */
+	public function __construct(
+		CommandInCommands $commandInCommands,
+		TestService $testService,
+		CommandAsService $commandAsService
+	)
+	{
+		parent::__construct();
+		$this->__dttConstruct($commandInCommands, $testService, $commandAsService);
+	}
+}
+
+/**
+ * Used for testing the dependencies
+ * @package KdybyTests\Console\DI
+ */
+trait DependencyTesterTrait
+{
+	/** @var CommandInCommands */
+	private $constructorCommandInCommands;
+
+	/** @var TestService */
+	private $constructorTestService;
+
+	/** @var CommandAsService */
+	private $constructorCommandAsService;
+
+	/** @var CommandInCommands */
+	private $injectorCommandInCommands;
+
+	/** @var TestService */
+	private $injectorTestService;
+
+	/** @var CommandAsService */
+	private $injectorCommandAsService;
+
+	/** @var CommandInCommands @inject */
+	public $annotationCommandInCommands;
+
+	/** @var TestService @inject */
+	public $annotationTestService;
+
+	/** @var CommandAsService @inject */
+	public $annotationCommandAsService;
+
+	/**
+	 * @param CommandInCommands $commandInCommands
+	 * @param TestService $testService
+	 * @param CommandAsService $commandAsService
+	 */
+	public function __construct(
+		CommandInCommands $commandInCommands,
+		TestService $testService,
+		CommandAsService $commandAsService
+	)
+	{
+		$this->constructorCommandInCommands = $commandInCommands;
+		$this->constructorTestService = $testService;
+		$this->constructorCommandAsService = $commandAsService;
+	}
+
+	/**
+	 * @param CommandInCommands $injectorCommandInCommands
+	 */
+	public function injectInjectorCommandInCommands(CommandInCommands $injectorCommandInCommands)
+	{
+		$this->injectorCommandInCommands = $injectorCommandInCommands;
+	}
+
+	/**
+	 * @param TestService $injectorTestService
+	 */
+	public function injectInjectorTestService(TestService $injectorTestService)
+	{
+		$this->injectorTestService = $injectorTestService;
+	}
+
+	/**
+	 * @param CommandAsService $injectorCommandAsService
+	 */
+	public function injectInjectorCommandAsService(CommandAsService $injectorCommandAsService)
+	{
+		$this->injectorCommandAsService = $injectorCommandAsService;
+	}
+
+	/**
+	 * @throws \Tester\AssertException if constructor injects fail (NOT nonsense, since this is a trait -- constructor is overriden)
+	 */
+	public function validateConstructor()
+	{
+		Assert::type('KdybyTests\Console\DI\CommandInCommands', $this->constructorCommandInCommands, 'Constructor fail');
+		Assert::type('KdybyTests\Console\DI\TestService', $this->constructorTestService, 'Constructor fail');
+		Assert::type('KdybyTests\Console\DI\CommandAsService', $this->constructorCommandAsService, 'Constructor fail');
+	}
+
+	/**
+	 * @throws \Tester\AssertException if annotation injects failed
+	 */
+	public function validateAnnotations()
+	{
+		Assert::type('KdybyTests\Console\DI\CommandInCommands', $this->annotationCommandInCommands, 'Annotation fail');
+		Assert::type('KdybyTests\Console\DI\TestService', $this->annotationTestService, 'Annotation fail');
+		Assert::type('KdybyTests\Console\DI\CommandAsService', $this->annotationCommandAsService, 'Annotation fail');
+	}
+
+	/**
+	 * @throws \Tester\AssertException if annotation not injects failed
+	 */
+	public function validateNotAnnotations()
+	{
+		Assert::same(null, $this->annotationCommandInCommands, 'Annotation fail');
+		Assert::same(null, $this->annotationTestService, 'Annotation fail');
+		Assert::same(null, $this->annotationCommandAsService, 'Annotation fail');
+	}
+
+	/**
+	 * @throws \Tester\AssertException if injector injects failed
+	 */
+	public function validateInjector()
+	{
+		Assert::type('KdybyTests\Console\DI\CommandInCommands', $this->injectorCommandInCommands, 'Injector fail');
+		Assert::type('KdybyTests\Console\DI\TestService', $this->injectorTestService, 'Injector fail');
+		Assert::type('KdybyTests\Console\DI\CommandAsService', $this->injectorCommandAsService, 'Injector fail');
+	}
+
+	/**
+	 * @throws \Tester\AssertException if injector injects did not fail
+	 */
+	public function validateNotInjector()
+	{
+		Assert::same(null, $this->injectorCommandInCommands, 'Injector fail');
+		Assert::same(null, $this->injectorTestService, 'Injector fail');
+		Assert::same(null, $this->injectorCommandAsService, 'Injector fail');
+	}
+
+}
+
+/**
+ * Basic command defined in commands section, without any dependencies
+ * @package KdybyTests\Console\DI
+ */
+class CommandInCommands extends DiTestCommand
+{
+	const COMMAND_NAME = 'app:commands:command';
+	const RETURN_CODE = 20;
+}
+
+/**
+ * Basic command defined in services, without any dependencies
+ * @package KdybyTests\Console\DI
+ */
+class CommandAsService extends DiTestCommand
+{
+	const COMMAND_NAME = 'app:services:command';
+	const RETURN_CODE = 30;
+}
+
+/**
+ * Command defined in commands section, that needs all dependencies
+ * @package KdybyTests\Console\DI
+ */
+class CommandInCommandsNeedsAll extends DiTestDependantCommand
+{
+	const COMMAND_NAME = 'app:commands:needsAll';
+	const RETURN_CODE = 110;
+}
+
+/**
+ * Command defined in services section, that needs all dependencies
+ * @package KdybyTests\Console\DI
+ */
+class CommandAsServiceNeedsAll extends DiTestDependantCommand
+{
+	const COMMAND_NAME = 'app:services:needsAll';
+	const RETURN_CODE = 120;
+}
+
+/**
+ * Command defined in services section, that needs all dependencies
+ * @package KdybyTests\Console\DI
+ */
+class CommandInCommandsNeedsAllWithInject extends DiTestDependantCommand
+{
+	const COMMAND_NAME = 'app:commands:needsAllWithInject';
+	const RETURN_CODE = 130;
+}
+
+/**
+ * Command defined in services section, that needs all dependencies
+ * @package KdybyTests\Console\DI
+ */
+class CommandAsServiceNeedsAllWithInject extends DiTestDependantCommand
+{
+	const COMMAND_NAME = 'app:services:needsAllWithInject';
+	const RETURN_CODE = 140;
+}
+
+/**
+ * Basic test service defined in services, without any dependencies
+ * @package KdybyTests\Console\DI
+ */
+class TestService
+{
+}
+
+/**
+ * Helper defined in console.helpers section
+ * @package KdybyTests\Console\DI
+ */
+class HelperInSection extends Helper
+{
+	public function getName()
+	{
+		return 'HelperInSection';
+	}
+}
+
+/**
+ * Helper defined in services section
+ * @package KdybyTests\Console\DI
+ */
+class HelperAsService extends Helper
+{
+	public function getName()
+	{
+		return 'HelperAsService';
+	}
+}
+
+\run(new DiWiringTest());

--- a/tests/KdybyTests/Console/config/di-wiring.neon
+++ b/tests/KdybyTests/Console/config/di-wiring.neon
@@ -1,0 +1,28 @@
+console:
+	commands:
+		- KdybyTests\Console\DI\CommandInCommands
+		- KdybyTests\Console\DI\CommandInCommandsNeedsAll
+		-
+			class: KdybyTests\Console\DI\CommandInCommandsNeedsAllWithInject
+			inject: true
+	helpers:
+		- KdybyTests\Console\DI\HelperInSection
+
+extensions:
+	console: Kdyby\Console\DI\ConsoleExtension
+
+services:
+	service1: KdybyTests\Console\DI\TestService
+	-
+		class: KdybyTests\Console\DI\CommandAsService
+		tags: [kdyby.console.command]
+	-
+		class: KdybyTests\Console\DI\HelperAsService
+		tags: [kdyby.console.helper]
+	-
+		class: KdybyTests\Console\DI\CommandAsServiceNeedsAll
+		tags: [kdyby.console.command]
+	-
+		class: KdybyTests\Console\DI\CommandAsServiceNeedsAllWithInject
+		inject: true
+		tags: [kdyby.console.command]


### PR DESCRIPTION
|  |  |
| --- | --- |
| **Type** | Feature |
| **Fixes issues** | fixes #46, fixes #48 |
| **Documentation** | updated |
| **BC Break** | **YES** |
| **Tests updated** | yes |

Updated the `ConsoleExtension`, so that it uses `Nette\DI` for parsing individual commands.

Therefore, full-blown Nette DI is possible - you can set `inject` and `autowire` and all options on every single individual service. However, this is a BC break, because previously all commands were **not** autowired and were injected instead.

This change, alongside with the documentation update, should adhere to nette coding practice of defining all dependencies on constructor level. Even though symfony recommends to use arbitraty `configure` method, using constructor is cleaner design IMHO.

**edit** see [this link](https://github.com/foglcz/Console/blob/feat-di-wiring/tests/KdybyTests/Console/config/di-wiring.neon) for new abilities in `config.neon`
