### PR TITLE
Drop PHP 5.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
     - NETTE=nette-2.3 COMPOSER_EXTRA_ARGS="--prefer-lowest"
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ before_script:
   - composer create-project --prefer-source --no-interaction jakub-onderka/php-parallel-lint vendor/php-parallel-lint ~0.8
   - php vendor/php-parallel-lint/parallel-lint.php -e php,phpt --exclude vendor .
   - composer create-project --prefer-source --no-interaction nette/code-checker vendor/code-checker ~2.2
-  - php vendor/code-checker/src/code-checker.php -d src
-  - php vendor/code-checker/src/code-checker.php -d tests
+  - php vendor/code-checker/src/code-checker.php --short-arrays -d src
+  - php vendor/code-checker/src/code-checker.php --short-arrays -d tests
 
 script: vendor/bin/tester -s -p php -c ./tests/php.ini-unix ./tests/KdybyTests/
 

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,10 @@
 		"issues": "https://github.com/kdyby/console/issues"
 	},
 	"require": {
+		"php": ">=5.3.3",
 		"nette/di": "~2.3@dev",
 
-		"symfony/console": "~2.3"
+		"symfony/console": "~2.4"
 	},
 	"require-dev": {
 		"nette/application": "~2.3@dev",

--- a/src/Kdyby/Console/Application.php
+++ b/src/Kdyby/Console/Application.php
@@ -35,11 +35,11 @@ class Application extends Symfony\Component\Console\Application
 	const INPUT_ERROR_EXIT_CODE = 253;
 	const INVALID_APP_MODE_EXIT_CODE = 252;
 
-	private static $invalidArgumentExceptions = array(
+	private static $invalidArgumentExceptions = [
 		'RuntimeException',
 		'InvalidArgumentException',
 		'Symfony\Component\Console\Exception\RuntimeException',
-	);
+	];
 
 	/**
 	 * @var Nette\DI\Container
@@ -93,7 +93,7 @@ class Application extends Symfony\Component\Console\Application
 		$output = $output ?: new ConsoleOutput();
 
 		if ($input->hasParameterOption('--debug-mode')) {
-			if ($input->hasParameterOption(array('--debug-mode=no', '--debug-mode=off', '--debug-mode=false', '--debug-mode=0'))) {
+			if ($input->hasParameterOption(['--debug-mode=no', '--debug-mode=off', '--debug-mode=false', '--debug-mode=0'])) {
 				if ($this->serviceLocator->parameters['debugMode']) {
 					$this->renderException(new InvalidApplicationModeException(
 						"The app is running in debug mode. You have to use Kdyby\\Console\\DI\\BootstrapHelper in app/bootstrap.php, " .

--- a/src/Kdyby/Console/CliRouter.php
+++ b/src/Kdyby/Console/CliRouter.php
@@ -30,7 +30,7 @@ class CliRouter extends Nette\Object implements Nette\Application\IRouter
 	/**
 	 * @var array
 	 */
-	public $allowedMethods = array('cli');
+	public $allowedMethods = ['cli'];
 
 	/**
 	 * @var \Nette\DI\Container
@@ -96,11 +96,11 @@ class CliRouter extends Nette\Object implements Nette\Application\IRouter
 			$output = new ConsoleOutput();
 		}
 
-		return new Request('Kdyby:Cli', 'cli', array(
+		return new Request('Kdyby:Cli', 'cli', [
 			'action' => 'default',
 			'input' => $input,
 			'output' => $output,
-		));
+		]);
 	}
 
 

--- a/src/Kdyby/Console/DI/BootstrapHelper.php
+++ b/src/Kdyby/Console/DI/BootstrapHelper.php
@@ -57,7 +57,7 @@ class BootstrapHelper extends Nette\Object
 			return FALSE;
 		}
 
-		if ($input->hasParameterOption(array('--debug-mode=no', '--debug-mode=off', '--debug-mode=false', '--debug-mode=0'))) {
+		if ($input->hasParameterOption(['--debug-mode=no', '--debug-mode=off', '--debug-mode=false', '--debug-mode=0'])) {
 			$configurator->setDebugMode(FALSE);
 			return TRUE;
 

--- a/src/Kdyby/Console/DI/ConsoleExtension.php
+++ b/src/Kdyby/Console/DI/ConsoleExtension.php
@@ -32,15 +32,15 @@ class ConsoleExtension extends Nette\DI\CompilerExtension
 	/**
 	 * @var array
 	 */
-	public $defaults = array(
+	public $defaults = [
 		'name' => 'Nette Framework',
 		'version' => 'unknown',
-		'commands' => array(),
+		'commands' => [],
 		'url' => NULL,
 		'disabled' => TRUE,
 		'application' => TRUE,
 		'fakeHttp' => TRUE,
-	);
+	];
 
 
 
@@ -63,8 +63,8 @@ class ConsoleExtension extends Nette\DI\CompilerExtension
 		$this->loadHelperSet($config);
 
 		$builder->addDefinition($this->prefix('application'))
-			->setClass('Kdyby\Console\Application', array($config['name'], $config['version']))
-			->addSetup('setHelperSet', array($this->prefix('@helperSet')))
+			->setClass('Kdyby\Console\Application', [$config['name'], $config['version']])
+			->addSetup('setHelperSet', [$this->prefix('@helperSet')])
 			->addSetup('injectServiceLocator')
 			->setInject(FALSE);
 
@@ -82,9 +82,9 @@ class ConsoleExtension extends Nette\DI\CompilerExtension
 		Nette\Utils\Validators::assert($config, 'array');
 		foreach ($config['commands'] as $i => $command) {
 			$def = $builder->addDefinition($this->prefix('command.' . $i));
-			list($def->factory) = Nette\DI\Compiler::filterArguments(array(
+			list($def->factory) = Nette\DI\Compiler::filterArguments([
 				is_string($command) ? new Statement($command) : $command
-			));
+			]);
 
 			if (class_exists($def->factory->entity)) {
 				$def->class = $def->factory->entity;
@@ -106,13 +106,13 @@ class ConsoleExtension extends Nette\DI\CompilerExtension
 			->setClass('Symfony\Component\Console\Helper\HelperSet')
 			->setInject(FALSE);
 
-		$helperClasses = array(
+		$helperClasses = [
 			'Symfony\Component\Console\Helper\ProcessHelper',
 			'Symfony\Component\Console\Helper\DescriptorHelper',
 			'Symfony\Component\Console\Helper\FormatterHelper',
 			'Symfony\Component\Console\Helper\QuestionHelper',
 			'Symfony\Component\Console\Helper\DebugFormatterHelper',
-		);
+		];
 
 		if ($config['application'] && $this->isNetteApplicationPresent()) {
 			$helperClasses[] = 'Kdyby\Console\Helpers\PresenterHelper';
@@ -123,8 +123,8 @@ class ConsoleExtension extends Nette\DI\CompilerExtension
 		}, $helperClasses);
 
 		// BC
-		$helpers[] = new Statement('Symfony\Component\Console\Helper\ProgressHelper', array(FALSE));
-		$helpers[] = new Statement('Symfony\Component\Console\Helper\DialogHelper', array(FALSE));
+		$helpers[] = new Statement('Symfony\Component\Console\Helper\ProgressHelper', [FALSE]);
+		$helpers[] = new Statement('Symfony\Component\Console\Helper\DialogHelper', [FALSE]);
 
 		foreach ($helpers as $helper) {
 			if (!class_exists($helper->entity)) {
@@ -132,13 +132,13 @@ class ConsoleExtension extends Nette\DI\CompilerExtension
 			}
 
 			if (!self::hasConstructor($helper->entity)) {
-				$helper->arguments = array();
+				$helper->arguments = [];
 			}
 
-			$helperSet->addSetup('set', array($helper));
+			$helperSet->addSetup('set', [$helper]);
 		}
 
-		$helperSet->addSetup('set', array(new Statement('Kdyby\Console\ContainerHelper'), 'dic'));
+		$helperSet->addSetup('set', [new Statement('Kdyby\Console\ContainerHelper'), 'dic']);
 	}
 
 
@@ -157,12 +157,12 @@ class ConsoleExtension extends Nette\DI\CompilerExtension
 
 		$helperSet = $builder->getDefinition($this->prefix('helperSet'));
 		foreach ($builder->findByTag(self::TAG_HELPER) as $serviceName => $value) {
-			$helperSet->addSetup('set', array('@' . $serviceName, $value));
+			$helperSet->addSetup('set', ['@' . $serviceName, $value]);
 		}
 
 		$app = $builder->getDefinition($this->prefix('application'));
 		foreach ($builder->findByTag(self::TAG_COMMAND) as $serviceName => $_) {
-			$app->addSetup('add', array('@' . $serviceName));
+			$app->addSetup('add', ['@' . $serviceName]);
 		}
 
 		$sfDispatcher = $builder->getByType('Symfony\Component\EventDispatcher\EventDispatcherInterface') ?: 'events.symfonyProxy';
@@ -196,7 +196,7 @@ class ConsoleExtension extends Nette\DI\CompilerExtension
 			->addSetup('Kdyby\Console\CliRouter::prependTo($service, ?)', [$this->prefix('@router')]);
 
 		$builder->getDefinition($builder->getByType('Nette\Application\IPresenterFactory') ?: 'nette.presenterFactory')
-			->addSetup('if (method_exists($service, ?)) { $service->setMapping(array(? => ?)); } ' .
+			->addSetup('if (method_exists($service, ?)) { $service->setMapping([? => ?]); } ' .
 				'elseif (property_exists($service, ?)) { $service->mapping[?] = ?; }', [
 				'setMapping', 'Kdyby', 'KdybyModule\*\*Presenter', 'mapping', 'Kdyby', 'KdybyModule\*\*Presenter'
 			]);
@@ -218,7 +218,7 @@ class ConsoleExtension extends Nette\DI\CompilerExtension
 			}
 			$builder->getDefinition($builder->getByType('Nette\Http\RequestFactory') ?: 'nette.httpRequestFactory')
 				->setFactory('Kdyby\Console\HttpRequestFactory')
-				->addSetup('setFakeRequestUrl', array($config['url']));
+				->addSetup('setFakeRequestUrl', [$config['url']]);
 		}
 	}
 

--- a/src/Kdyby/Console/HttpRequestFactory.php
+++ b/src/Kdyby/Console/HttpRequestFactory.php
@@ -47,7 +47,7 @@ class HttpRequestFactory extends Nette\Http\RequestFactory
 			return parent::createHttpRequest();
 		}
 
-		return new Nette\Http\Request($this->fakeUrl, NULL, array(), array(), array(), array(), PHP_SAPI, '127.0.0.1', '127.0.0.1');
+		return new Nette\Http\Request($this->fakeUrl, NULL, [], [], [], [], PHP_SAPI, '127.0.0.1', '127.0.0.1');
 	}
 
 }

--- a/tests/KdybyTests/Console/Application.phpt
+++ b/tests/KdybyTests/Console/Application.phpt
@@ -34,7 +34,7 @@ class ApplicationTest extends Tester\TestCase
 	{
 		$config = new Nette\Configurator();
 		$config->setTempDirectory(TEMP_DIR);
-		$config->addParameters(array('container' => array('class' => 'SystemContainer_' . Nette\Utils\Strings::random())));
+		$config->addParameters(['container' => ['class' => 'SystemContainer_' . Nette\Utils\Strings::random()]]);
 		Kdyby\Console\DI\ConsoleExtension::register($config);
 		Kdyby\Events\DI\EventsExtension::register($config);
 		$config->addConfig(__DIR__ . '/config/allow.neon', $config::NONE);
@@ -57,11 +57,11 @@ class ApplicationTest extends Tester\TestCase
 		$app = $container->getByType('Kdyby\Console\Application');
 		$tester = new ApplicationTester($app);
 
-		Assert::same(0, $tester->run(array('list')));
-		Assert::same(array(
-			array('command', 'Symfony\\Component\\Console\\Command\\ListCommand'),
-			array('terminate', 'Symfony\\Component\\Console\\Command\\ListCommand', 0),
-		), $listener->calls);
+		Assert::same(0, $tester->run(['list']));
+		Assert::same([
+			['command', 'Symfony\\Component\\Console\\Command\\ListCommand'],
+			['terminate', 'Symfony\\Component\\Console\\Command\\ListCommand', 0],
+		], $listener->calls);
 	}
 
 }
@@ -71,37 +71,37 @@ class ApplicationTest extends Tester\TestCase
 class ConsoleListener extends Nette\Object implements Kdyby\Events\Subscriber
 {
 
-	public $calls = array();
+	public $calls = [];
 
 
 	public function getSubscribedEvents()
 	{
-		return array(
+		return [
 			ConsoleEvents::COMMAND,
 			ConsoleEvents::EXCEPTION,
 			ConsoleEvents::TERMINATE,
-		);
+		];
 	}
 
 
 
 	public function command(ConsoleCommandEvent $event)
 	{
-		$this->calls[] = array(__FUNCTION__, get_class($event->getCommand()));
+		$this->calls[] = [__FUNCTION__, get_class($event->getCommand())];
 	}
 
 
 
 	public function exception(ConsoleExceptionEvent $event)
 	{
-		$this->calls[] = array(__FUNCTION__, get_class($event->getCommand()), $event->getException());
+		$this->calls[] = [__FUNCTION__, get_class($event->getCommand()), $event->getException()];
 	}
 
 
 
 	public function terminate(ConsoleTerminateEvent $event)
 	{
-		$this->calls[] = array(__FUNCTION__, get_class($event->getCommand()), $event->getExitCode());
+		$this->calls[] = [__FUNCTION__, get_class($event->getCommand()), $event->getExitCode()];
 	}
 
 }

--- a/tests/KdybyTests/Console/CliAppTester.php
+++ b/tests/KdybyTests/Console/CliAppTester.php
@@ -82,7 +82,7 @@ class CliAppTester
 	 *
 	 * @return int     The command exit code
 	 */
-	public function run(array $input, $options = array())
+	public function run(array $input, $options = [])
 	{
 		$this->input = new ArgvInput($input);
 		if (isset($options['interactive'])) {

--- a/tests/KdybyTests/Console/CliRouter.phpt
+++ b/tests/KdybyTests/Console/CliRouter.phpt
@@ -56,8 +56,8 @@ class CliRouterTest extends Tester\TestCase
 
 		// create presenter
 		$presenter = new KdybyModule\CliPresenter();
-		$container->callMethod(array($presenter, 'injectPrimary'));
-		$container->callMethod(array($presenter, 'injectConsole'));
+		$container->callMethod([$presenter, 'injectPrimary']);
+		$container->callMethod([$presenter, 'injectConsole']);
 
 		// run presenter
 		$appResponse = $presenter->run($appRequest);

--- a/tests/KdybyTests/Console/Extension.phpt
+++ b/tests/KdybyTests/Console/Extension.phpt
@@ -30,7 +30,7 @@ class ExtensionTest extends Tester\TestCase
 	{
 		$config = new Nette\Configurator();
 		$config->setTempDirectory(TEMP_DIR);
-		$config->addParameters(array('container' => array('class' => 'SystemContainer_' . Nette\Utils\Strings::random())));
+		$config->addParameters(['container' => ['class' => 'SystemContainer_' . Nette\Utils\Strings::random()]]);
 		Kdyby\Console\DI\ConsoleExtension::register($config);
 		$config->addConfig(__DIR__ . '/config/allow.neon', $config::NONE);
 

--- a/tests/KdybyTests/Console/InputErrors.phpt
+++ b/tests/KdybyTests/Console/InputErrors.phpt
@@ -43,7 +43,7 @@ class InputErrorsTest extends Tester\TestCase
 	{
 		$config = new Nette\Configurator();
 		$config->setTempDirectory(TEMP_DIR);
-		$config->addParameters(array('container' => array('class' => 'SystemContainer_' . Nette\Utils\Strings::random())));
+		$config->addParameters(['container' => ['class' => 'SystemContainer_' . Nette\Utils\Strings::random()]]);
 		Kdyby\Console\DI\ConsoleExtension::register($config);
 		Kdyby\Events\DI\EventsExtension::register($config);
 		$config->addConfig(__DIR__ . '/config/input-errors.neon', $config::NONE);
@@ -71,18 +71,18 @@ class InputErrorsTest extends Tester\TestCase
 		$app = $container->getByType('Kdyby\Console\Application');
 		$tester = new ApplicationTester($app);
 
-		Assert::same(Kdyby\Console\Application::INPUT_ERROR_EXIT_CODE, $tester->run(array('tipo')));
-		Assert::same(array(), $listener->calls);
+		Assert::same(Kdyby\Console\Application::INPUT_ERROR_EXIT_CODE, $tester->run(['tipo']));
+		Assert::same([], $listener->calls);
 	}
 
 
 
 	public function getAmbiguousCommandData()
 	{
-		return array(
-			array(array('ambiguous'), '%a% ambiguous %a%'),
-			array(array('name:ambi'), '%a% ambiguous %a%'),
-		);
+		return [
+			[['ambiguous'], '%a% ambiguous %a%'],
+			[['name:ambi'], '%a% ambiguous %a%'],
+		];
 	}
 
 
@@ -109,21 +109,21 @@ class InputErrorsTest extends Tester\TestCase
 		$tester = new ApplicationTester($app);
 
 		Assert::same(Kdyby\Console\Application::INPUT_ERROR_EXIT_CODE, $tester->run($arguments));
-		Assert::same(array(), $listener->calls);
+		Assert::same([], $listener->calls);
 	}
 
 
 
 	public function getNotLoggingUnknownArgumentData()
 	{
-		return array(
-			array(array('arg'), 'Not enough arguments%A?%'),
-			array(array('arg', 'first', 'second', 'third'), 'Too many arguments.'),
-			array(array('arg', '--non-existent-option', 'first'), 'The "--%a%" option does not exist.'),
-			array(array('arg', '-aa', 'first'), 'The "-%a%" option does not exist.'),
-			array(array('arg', '--no-value=1', 'first'), 'The "--%a%" option does not accept a value.'),
-			array(array('arg', '--existent', '--no-value', 'first'), 'The "--%a%" option requires a value.'),
-		);
+		return [
+			[['arg'], 'Not enough arguments%A?%'],
+			[['arg', 'first', 'second', 'third'], 'Too many arguments.'],
+			[['arg', '--non-existent-option', 'first'], 'The "--%a%" option does not exist.'],
+			[['arg', '-aa', 'first'], 'The "-%a%" option does not exist.'],
+			[['arg', '--no-value=1', 'first'], 'The "--%a%" option does not accept a value.'],
+			[['arg', '--existent', '--no-value', 'first'], 'The "--%a%" option requires a value.'],
+		];
 	}
 
 
@@ -174,37 +174,37 @@ class InputErrorsTest extends Tester\TestCase
 class ConsoleListener extends Nette\Object implements Kdyby\Events\Subscriber
 {
 
-	public $calls = array();
+	public $calls = [];
 
 
 	public function getSubscribedEvents()
 	{
-		return array(
+		return [
 			ConsoleEvents::COMMAND,
 			ConsoleEvents::EXCEPTION,
 			ConsoleEvents::TERMINATE,
-		);
+		];
 	}
 
 
 
 	public function command(ConsoleCommandEvent $event)
 	{
-		$this->calls[] = array(__FUNCTION__, get_class($event->getCommand()));
+		$this->calls[] = [__FUNCTION__, get_class($event->getCommand())];
 	}
 
 
 
 	public function exception(ConsoleExceptionEvent $event)
 	{
-		$this->calls[] = array(__FUNCTION__, get_class($event->getCommand()), $event->getException());
+		$this->calls[] = [__FUNCTION__, get_class($event->getCommand()), $event->getException()];
 	}
 
 
 
 	public function terminate(ConsoleTerminateEvent $event)
 	{
-		$this->calls[] = array(__FUNCTION__, get_class($event->getCommand()), $event->getExitCode());
+		$this->calls[] = [__FUNCTION__, get_class($event->getCommand()), $event->getExitCode()];
 	}
 
 }
@@ -214,7 +214,7 @@ class ConsoleListener extends Nette\Object implements Kdyby\Events\Subscriber
 class TestLogger extends Tracy\Logger
 {
 
-	public $messages = array();
+	public $messages = [];
 
 
 

--- a/tests/KdybyTests/bootstrap.php
+++ b/tests/KdybyTests/bootstrap.php
@@ -23,10 +23,11 @@ define('TEMP_DIR', __DIR__ . '/../tmp/' . (isset($_SERVER['argv']) ? md5(seriali
 Tester\Helpers::purge(TEMP_DIR);
 
 
-$_SERVER = array_intersect_key($_SERVER, array_flip(array(
-	'PHP_SELF', 'SCRIPT_NAME', 'SERVER_ADDR', 'SERVER_SOFTWARE', 'HTTP_HOST', 'DOCUMENT_ROOT', 'OS', 'argc', 'argv')));
+$_SERVER = array_intersect_key($_SERVER, array_flip([
+	'PHP_SELF', 'SCRIPT_NAME', 'SERVER_ADDR', 'SERVER_SOFTWARE', 'HTTP_HOST', 'DOCUMENT_ROOT', 'OS', 'argc', 'argv'
+]));
 $_SERVER['REQUEST_TIME'] = 1234567890;
-$_ENV = $_GET = $_POST = array();
+$_ENV = $_GET = $_POST = [];
 
 function id($val) {
 	return $val;


### PR DESCRIPTION
I'd like to upgrade upgrade `symfony/console` at least to version 2.4 to be able to use short array syntax. Unfortunately 2.4 minimum php version is `>=5.3.3`, so php 5.4 support needs to be dropped. 

Maybe I could look on `symfony/console` changes and try upgrade to version 3.0 insted. Are you interested?