### PR TITLE
Allow symfony/console 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		"php": ">=5.4",
 		"nette/di": "~2.3@dev",
 
-		"symfony/console": "~2.3"
+		"symfony/console": "~2.3|~3.0"
 	},
 	"require-dev": {
 		"nette/application": "~2.3@dev",

--- a/src/Kdyby/Console/Application.php
+++ b/src/Kdyby/Console/Application.php
@@ -176,18 +176,6 @@ class Application extends Symfony\Component\Console\Application
 
 
 
-	public function renderException($e, $output)
-	{
-		if ($output instanceof ConsoleOutputInterface) {
-			parent::renderException($e, $output->getErrorOutput());
-
-		} else {
-			parent::renderException($e, $output);
-		}
-	}
-
-
-
 	protected function doRunCommand(Command $command, InputInterface $input, OutputInterface $output)
 	{
 		if ($this->serviceLocator) {


### PR DESCRIPTION
Unfortunately symfony/console 3.0 contains a BC break - the header of renderException method now contains type hints which means a separate version of kdyby/console would be needed for symfony 3.x.

In my opinion its better to remove this method from Kdyby. The condition is [used](https://github.com/symfony/console/blob/50c745b4f1047632f7e46a70ba010789c4a9e385/Application.php#L123-L127) when calling this method anyway so the only change is when calling it manually.