### PR TITLE
Fix detection of nette/application

### DIFF
--- a/src/Kdyby/Console/DI/ConsoleExtension.php
+++ b/src/Kdyby/Console/DI/ConsoleExtension.php
@@ -252,7 +252,7 @@ class ConsoleExtension extends Nette\DI\CompilerExtension
 	 */
 	private function isNetteApplicationPresent()
 	{
-		return class_exists('Nette\Application\Application');
+		return (bool) $this->compiler->getExtensions('Nette\Bridges\ApplicationDI\ApplicationExtension');
 	}
 
 


### PR DESCRIPTION
Currently some of my tests are failing with

```
[Nette\DI\MissingServiceException] Service 'application' not found.
```

because I have nette/application in dev dependencies but don't use it in all the tests. The problem occurs if a test uses ConsoleExtension without ApplicationExtension.

@fprochazka Should I refactor it to a property like I did [here](https://github.com/enumag/Doctrine/blob/events/src/Kdyby/Doctrine/DI/OrmExtension.php#L142-L158)? Personally I like it better than a method.