### PR TITLE
Remove dependency on \Nette\Security\User

### DIFF
--- a/src/Kdyby/Console/CliPresenter.php
+++ b/src/Kdyby/Console/CliPresenter.php
@@ -12,6 +12,8 @@ namespace KdybyModule;
 
 use Kdyby;
 use Nette;
+use Nette\Application;
+use Nette\Http;
 
 
 
@@ -52,6 +54,14 @@ class CliPresenter extends Nette\Application\UI\Presenter
 		Nette\Utils\Validators::assertField($params, 'input', 'Symfony\Component\Console\Input\Input');
 		Nette\Utils\Validators::assertField($params, 'output', 'Symfony\Component\Console\Output\OutputInterface');
 		$this->sendResponse(new Kdyby\Console\CliResponse($this->console->run($params['input'], $params['output'])));
+	}
+
+
+
+	public function injectPrimary(Nette\DI\Container $context = NULL, Application\IPresenterFactory $presenterFactory = NULL, Application\IRouter $router = NULL,
+		Http\IRequest $httpRequest, Http\IResponse $httpResponse, Http\Session $session = NULL, ITemplateFactory $templateFactory = NULL)
+	{
+		parent::injectPrimary($context, $presenterFactory, $router, $httpRequest, $httpResponse, $session, NULL, $templateFactory);
 	}
 
 }


### PR DESCRIPTION
IMHO there is no point in using securityUser in CLI application.

With this dependency, the DI loads securityUser for presenter, authenticator for securityUser and DB connection for authenticator. I have problem with the last part, because in some CLI commands, I don't need to use DB connection so I don't have credentials set for DB so I got error.
