### PR TITLE
Fix exceptions handling with aplication option set to false

### DIFF
--- a/src/Kdyby/Console/Application.php
+++ b/src/Kdyby/Console/Application.php
@@ -137,11 +137,12 @@ class Application extends Symfony\Component\Console\Application
 				Debugger::log($e->getMessage(), Debugger::ERROR);
 				return self::INPUT_ERROR_EXIT_CODE;
 
-			} elseif ($app = $this->serviceLocator->getByType('Nette\Application\Application', FALSE)) {
-				/** @var Nette\Application\Application $app */
-				$app->onError($app, $e);
-
 			} else {
+				if ($app = $this->serviceLocator->getByType('Nette\Application\Application', FALSE)) {
+					/** @var Nette\Application\Application $app */
+					$app->onError($app, $e);
+				}
+
 				$this->handleException($e, $output);
 			}
 

--- a/src/Kdyby/Console/DI/ConsoleExtension.php
+++ b/src/Kdyby/Console/DI/ConsoleExtension.php
@@ -188,8 +188,7 @@ class ConsoleExtension extends Nette\DI\CompilerExtension
 				->addSetup('$self = $this; $service->onError[] = function ($app, $e) use ($self) {' . "\n" .
 					"\t" . '$app->errorPresenter = ?;' . "\n" .
 					"\t" . '$app->onShutdown[] = function () { exit(?); };' . "\n" .
-					"\t" . '$self->getService(?)->handleException($e); ' . "\n" .
-					'}', [FALSE, 254, $this->prefix('application')]);
+					'}', [FALSE, 254]);
 		}
 
 		$routerServiceName = $builder->getByType('Nette\Application\IRouter') ?: 'router';


### PR DESCRIPTION
```
kdyby.console:
    application: false
```

This configuration leads to a nasty bug - if a command throws an exception Kdyby\Console\Application will catch it and pass it to `$netteApplication->onError()`. The option however removed the binding which means that onError does not have any event handler and the exception is never rendered nor logged.
