### PR TITLE
nette 3.0 compatibility

### DIFF
--- a/src/DI/ConsoleExtension.php
+++ b/src/DI/ConsoleExtension.php
@@ -66,7 +66,7 @@ class ConsoleExtension extends Nette\DI\CompilerExtension
 	public function loadConfiguration()
 	{
 		$builder = $this->getContainerBuilder();
-		$config = $this->getConfig($this->defaults);
+		$config = $this->validateConfig($this->defaults);
 
 		$this->loadHelperSet($config);
 


### PR DESCRIPTION
getConfig hasn't any parameters.