### PR TITLE
require symfony/console as ^4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 		"nette/routing": "^3.0.0",
 		"tracy/tracy": "^2.5 || ^3.0",
 		"kdyby/strict-objects": "^2.0",
-		"symfony/console": "~2.3 || ^3.0 || < 4.3"
+		"symfony/console": "~2.3 || ^3.0 || ^4.0"
 	},
 	"require-dev": {
 		"nette/application": "^3.0",


### PR DESCRIPTION
Hello,

I was wondering why symfony/console is required as `<4.3` but couldn't find much except this comment:
https://github.com/Kdyby/Events/pull/120#discussion_r271074516

But it does not shed any light either.

In a wider sense, I want to ask what's going to happen to this package? Is it maintained still? There hasn't been nette 3 compatible version release yet, we are on dev-master right now and I bet there are many others like that using this package. There's already Symfony 5 and this package still has issues with 4. Shoulld I be looking for alternatives? @VBoss @enumag @fprochazka 