### PR TITLE
Nette\Http\RequestFactory BC break fixup

### DIFF
--- a/src/HttpRequestFactory.php
+++ b/src/HttpRequestFactory.php
@@ -37,10 +37,10 @@ class HttpRequestFactory extends \Nette\Http\RequestFactory
 		}
 	}
 
-	public function createHttpRequest(): \Nette\Http\Request
+	public function fromGlobals(): \Nette\Http\Request
 	{
 		if ($this->fakeUrl === NULL || PHP_SAPI !== Application::CLI_SAPI || !empty($_SERVER['REMOTE_HOST'])) {
-			return parent::createHttpRequest();
+			return parent::fromGlobals();
 		}
 
 		return new HttpRequest($this->fakeUrl, NULL, [], [], [], PHP_SAPI, PHP_SAPI, '127.0.0.1', NULL);

--- a/tests/KdybyTests/Console/HttpRequestFactoryTest.phpt
+++ b/tests/KdybyTests/Console/HttpRequestFactoryTest.phpt
@@ -31,7 +31,7 @@ class HttpRequestFactoryTest extends \Tester\TestCase
 			'/path/'
 		);
 
-		$httpRequest = $requestFactory->createHttpRequest();
+		$httpRequest = $requestFactory->fromGlobals();
 		Assert::same(Application::CLI_SAPI, $httpRequest->getMethod());
 
 		$presenterFactory = new PresenterFactory();


### PR DESCRIPTION
`HttpRequestFactory::createHttpRequest()` renamed to `fromGlobals()`
https://github.com/nette/http/commit/d73c9aa66b2bca1684204208804230f0fcb273fe

Note that using the old name actually breaks things as Nette already uses the new `fromGlobals` method to create the `Http\Request`, which is not overloaded. As a result, the fake URL is not used in console mode.