### PR TITLE
Add support for PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,26 +17,26 @@
 		"issues": "https://github.com/kdyby/console/issues"
 	},
 	"require": {
-		"php": ">=7.1",
+		"php": ">=7.1 || ^8.0",
 		"nette/di": "^2.4.10 || ^3.0",
 		"nette/routing": "^3.0.0",
 		"tracy/tracy": "^2.5 || ^3.0",
-		"kdyby/strict-objects": "^2.0",
-		"symfony/console": "~2.3 || ^3.0 || < 4.3"
+		"nette/utils": "^2.4 || ^3.0",
+		"symfony/console": "~2.3 || ^3.0 || ^4.0"
 	},
 	"require-dev": {
-		"nette/application": "3.0.*",
+		"nette/application": "^3.0",
 		"nette/bootstrap": "^2.4.5 || ^3.0",
 		"nette/caching": "^2.5 || ^3.0",
 		"nette/http": "^3.0",
-		"kdyby/events": "^3.2@dev",
-		"symfony/event-dispatcher": "~2.3 || ^3.0 || ^4.0 < 4.3",
+		"kdyby/events": "dev-patch-1 as 3.2.99",
+		"symfony/event-dispatcher": "~2.3 || ^3.0 || ^4.0",
 
 		"nette/tester": "^2.2",
-		"phpstan/phpstan-shim": "^0.11.5",
-		"kdyby/coding-standard": "dev-master",
+		"phpstan/phpstan": "0.12.*",
+		"doctrine/coding-standard": "8.2.*",
 		"php-coveralls/php-coveralls": "^2.1",
-		"jakub-onderka/php-parallel-lint": "^1.0",
+		"php-parallel-lint/php-parallel-lint": "^v1.2.0",
 		"typo3/class-alias-loader": "^1.0"
 	},
 	"suggest": {
@@ -58,7 +58,12 @@
 			"tests/KdybyTests/"
 		]
 	},
-	"minimum-stability": "dev",
+	"repositories": [
+		{
+			"type": "vcs",
+			"url": "https://github.com/dakorpar/Events.git"
+		}
+	],
 	"extra": {
 		"branch-alias": {
 			"dev-master": "2.8-dev"

--- a/src/Application.php
+++ b/src/Application.php
@@ -27,7 +27,7 @@ use Tracy\Dumper;
 class Application extends \Symfony\Component\Console\Application
 {
 
-	use \Kdyby\StrictObjects\Scream;
+	use \Nette\SmartObject;
 
 	public const CLI_SAPI = 'cli';
 	public const INPUT_ERROR_EXIT_CODE = 253;

--- a/src/CliResponse.php
+++ b/src/CliResponse.php
@@ -19,7 +19,7 @@ use Nette\Http\IResponse;
 class CliResponse implements \Nette\Application\IResponse
 {
 
-	use \Kdyby\StrictObjects\Scream;
+	use \Nette\SmartObject;
 
 	/**
 	 * @var int

--- a/src/CliRouter.php
+++ b/src/CliRouter.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class CliRouter implements \Nette\Routing\Router
 {
 
-	use \Kdyby\StrictObjects\Scream;
+	use \Nette\SmartObject;
 
 	/**
 	 * @var string[]

--- a/src/ContainerHelper.php
+++ b/src/ContainerHelper.php
@@ -17,7 +17,7 @@ use Nette\DI\Container as DIContainer;
 class ContainerHelper extends \Symfony\Component\Console\Helper\Helper
 {
 
-	use \Kdyby\StrictObjects\Scream;
+	use \Nette\SmartObject;
 
 	/**
 	 * @var \Nette\DI\Container

--- a/src/DI/BootstrapHelper.php
+++ b/src/DI/BootstrapHelper.php
@@ -39,7 +39,7 @@ use Symfony\Component\Console\Input\ArgvInput;
 class BootstrapHelper
 {
 
-	use \Kdyby\StrictObjects\Scream;
+	use \Nette\SmartObject;
 
 	/**
 	 * @param \Nette\Configurator $configurator

--- a/src/Helpers/PresenterHelper.php
+++ b/src/Helpers/PresenterHelper.php
@@ -17,7 +17,7 @@ use Nette\Application\Application;
 class PresenterHelper extends \Symfony\Component\Console\Helper\Helper
 {
 
-	use \Kdyby\StrictObjects\Scream;
+	use \Nette\SmartObject;
 
 	/**
 	 * @var \Nette\Application\Application

--- a/src/StringOutput.php
+++ b/src/StringOutput.php
@@ -15,7 +15,7 @@ namespace Kdyby\Console;
 class StringOutput extends \Symfony\Component\Console\Output\Output
 {
 
-	use \Kdyby\StrictObjects\Scream;
+	use \Nette\SmartObject;
 
 	/**
 	 * @var string

--- a/tests/KdybyTests/Console/CliRouterTest.phpt
+++ b/tests/KdybyTests/Console/CliRouterTest.phpt
@@ -45,7 +45,7 @@ class CliRouterTest extends \Tester\TestCase
 		/** @var \Nette\Application\Routers\RouteList $router */
 		Assert::true($router instanceof RouteList);
 
-		[$cliRouter] = iterator_to_array($router->getIterator());
+		[$cliRouter] = $router->getRouters();
 		/** @var \Kdyby\Console\CliRouter $cliRouter */
 		Assert::true($cliRouter instanceof CliRouter);
 

--- a/tests/KdybyTests/Console/data/AmbiguousCommand1.php
+++ b/tests/KdybyTests/Console/data/AmbiguousCommand1.php
@@ -11,7 +11,7 @@ use Tester\Assert;
 class AmbiguousCommand1 extends \Symfony\Component\Console\Command\Command
 {
 
-	use \Kdyby\StrictObjects\Scream;
+	use \Nette\SmartObject;
 
 	protected function configure()
 	{

--- a/tests/KdybyTests/Console/data/AmbiguousCommand2.php
+++ b/tests/KdybyTests/Console/data/AmbiguousCommand2.php
@@ -11,7 +11,7 @@ use Tester\Assert;
 class AmbiguousCommand2 extends \Symfony\Component\Console\Command\Command
 {
 
-	use \Kdyby\StrictObjects\Scream;
+	use \Nette\SmartObject;
 
 	protected function configure()
 	{

--- a/tests/KdybyTests/Console/data/ArgCommand.php
+++ b/tests/KdybyTests/Console/data/ArgCommand.php
@@ -13,7 +13,7 @@ use Tester\Assert;
 class ArgCommand extends \Symfony\Component\Console\Command\Command
 {
 
-	use \Kdyby\StrictObjects\Scream;
+	use \Nette\SmartObject;
 
 	protected function configure()
 	{

--- a/tests/KdybyTests/Console/data/CliAppTester.php
+++ b/tests/KdybyTests/Console/data/CliAppTester.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\StreamOutput;
 class CliAppTester
 {
 
-	use \Kdyby\StrictObjects\Scream;
+	use \Nette\SmartObject;
 
 	/**
 	 * @var \Symfony\Component\Console\Application

--- a/tests/KdybyTests/Console/data/CommandMock.php
+++ b/tests/KdybyTests/Console/data/CommandMock.php
@@ -7,7 +7,7 @@ namespace KdybyTests\Console;
 class CommandMock extends \Symfony\Component\Console\Command\Command
 {
 
-	use \Kdyby\StrictObjects\Scream;
+	use \Nette\SmartObject;
 
 	protected function configure()
 	{

--- a/tests/KdybyTests/Console/data/ConsoleListener.php
+++ b/tests/KdybyTests/Console/data/ConsoleListener.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Event\ConsoleTerminateEvent;
 class ConsoleListener implements \Kdyby\Events\Subscriber
 {
 
-	use \Kdyby\StrictObjects\Scream;
+	use \Nette\SmartObject;
 
 	/**
 	 * @var string[][]

--- a/tests/KdybyTests/Console/data/NamespaceAmbiguousCommand1.php
+++ b/tests/KdybyTests/Console/data/NamespaceAmbiguousCommand1.php
@@ -11,7 +11,7 @@ use Tester\Assert;
 class NamespaceAmbiguousCommand1 extends \Symfony\Component\Console\Command\Command
 {
 
-	use \Kdyby\StrictObjects\Scream;
+	use \Nette\SmartObject;
 
 	protected function configure()
 	{

--- a/tests/KdybyTests/Console/data/NamespaceAmbiguousCommand2.php
+++ b/tests/KdybyTests/Console/data/NamespaceAmbiguousCommand2.php
@@ -11,7 +11,7 @@ use Tester\Assert;
 class NamespaceAmbiguousCommand2 extends \Symfony\Component\Console\Command\Command
 {
 
-	use \Kdyby\StrictObjects\Scream;
+	use \Nette\SmartObject;
 
 	protected function configure()
 	{

--- a/tests/KdybyTests/Console/data/SameArgsCommandOne.php
+++ b/tests/KdybyTests/Console/data/SameArgsCommandOne.php
@@ -11,7 +11,7 @@ use Tester\Assert;
 class SameArgsCommandOne extends \Symfony\Component\Console\Command\Command
 {
 
-	use \Kdyby\StrictObjects\Scream;
+	use \Nette\SmartObject;
 
 	/**
 	 * @var \KdybyTests\Console\ArgCommand

--- a/tests/KdybyTests/Console/data/SameArgsCommandTwo.php
+++ b/tests/KdybyTests/Console/data/SameArgsCommandTwo.php
@@ -11,7 +11,7 @@ use Tester\Assert;
 class SameArgsCommandTwo extends \Symfony\Component\Console\Command\Command
 {
 
-	use \Kdyby\StrictObjects\Scream;
+	use \Nette\SmartObject;
 
 	/**
 	 * @var \KdybyTests\Console\ArgCommand

--- a/tests/KdybyTests/Console/data/TypoCommand.php
+++ b/tests/KdybyTests/Console/data/TypoCommand.php
@@ -11,7 +11,7 @@ use Tester\Assert;
 class TypoCommand extends \Symfony\Component\Console\Command\Command
 {
 
-	use \Kdyby\StrictObjects\Scream;
+	use \Nette\SmartObject;
 
 	protected function configure()
 	{


### PR DESCRIPTION
 - Droped Kdyby/StrictObjects, replaced by Nette/SmartObject.
 - Unmaintaned Kdyby/CodingStandard replaced by Doctrine/CodingStandard.
 - Allowed Symfony/EventDispatcher 4.3 where is some break, run tests please.
 - Travis run only PHP 7.3, is there any plan for migrating to GHA?